### PR TITLE
Fix errors with labs 3 and 4

### DIFF
--- a/1120Lab3.ipynb
+++ b/1120Lab3.ipynb
@@ -21,6 +21,7 @@
     "# Sample code for calculating capacitance and uncertainties\n",
     "#-----------------------------------------------------------\n",
     "# Copyright Amelia Nishimura 2020 :v\n",
+    "# Modified by Christian Piper 2022\n",
     "#-----------------------------------------------------------\n",
     "\n",
     "# Define the two capacitance values and their respective uncertainties (get from LoggerPro)\n",
@@ -30,14 +31,14 @@
     "c2_uncertainty = 0.03\n",
     "\n",
     "# For the case where the capacitors are in parallel\n",
-    "c_parallel = c1 + c2\n",
-    "c_parallel_uncertainty = c1_uncertainty + c2_uncertainty\n",
-    "print(f'Total capacitance (parallel): {c_parallel} +/- {c_parallel_uncertainty} F')\n",
+    "c_parallel = c1 + c2 #Eq 5\n",
+    "c_parallel_uncertainty = c1_uncertainty + c2_uncertainty #Eq 6\n",
+    "print(f'Eq 2 & 5: Total capacitance (parallel): {c_parallel} +/- {c_parallel_uncertainty} μF')\n",
     "\n",
     "# For the case where the capacitors are in series\n",
     "c_series = (c1 * c2) / (c1 + c2)\n",
-    "c_series_uncertainty = (c1_uncertainty * ((c2 / c1 + c2) ** 2)) + (c2_uncertainty * ((c1 / c1 + c2) ** 2))\n",
-    "print(f'Total capacitance (series): {c_series} +/- {c_series_uncertainty} F')\n",
+    "c_series_uncertainty = (c1_uncertainty * ((c2 / (c1 + c2)) ** 2)) + (c2_uncertainty * ((c1 / (c1 + c2)) ** 2))\n",
+    "print(f'Eq 3 & 4: Total capacitance (series): {c_series} +/- {c_series_uncertainty} μF')\n",
     "\n",
     "#Remember to report with the proper number of significant figures! "
    ]
@@ -66,7 +67,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/1120Lab4.ipynb
+++ b/1120Lab4.ipynb
@@ -18,7 +18,8 @@
     "#===========================================================\n",
     "# WPI PHYSICS DEPARTMENT - 2020-2021\n",
     "# PH1120/21 Lab 4 - Resistance\n",
-    "# Modified from sample code for calculating capacitance and uncertainties by Amelia Nishimura 2020 :v\n",
+    "# Modified from sample code for calculating capacitance and uncertainties by Amelia Nishimura 2020\n",
+    "# Modified by Christian Piper 2022\n",
     "#-----------------------------------------------------------\n",
     "\n",
     "# Define the two resistor values and their respective uncertainties (get from LoggerPro)\n",
@@ -27,15 +28,15 @@
     "r2 = 4.0\n",
     "r2_uncertainty = 0.03\n",
     "\n",
-    "# For the case where the capacitors are in series\n",
+    "# For the case where the resistors are in series\n",
     "r_series = r1 + r2\n",
     "r_series_uncertainty = r1_uncertainty + r2_uncertainty\n",
-    "print(f'Total resistance (series): {r_series} +/- {r_series_uncertainty} F')\n",
+    "print(f'Total resistance (series): {r_series} +/- {r_series_uncertainty} Ω')\n",
     "\n",
-    "# For the case where the resistor are parallel\n",
+    "# For the case where the resistors are parallel\n",
     "r_parallel = ((1/r1) + (1/r2))**-1\n",
     "r_parallel_uncertainty = (r1_uncertainty * ((r2**2 / ((r1 + r2) ** 2)))) + (r2_uncertainty * ((r1**2) / ((r1 + r2) ** 2)))\n",
-    "print(f'Total restance (parallel): {r_parallel} +/- {r_parallel_uncertainty} F')\n",
+    "print(f'Total restance (parallel): {r_parallel} +/- {r_parallel_uncertainty} Ω')\n",
     "\n",
     "#Remember to report with the proper number of significant figures!"
    ]
@@ -64,7 +65,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Lab 3 had issues with uncertainty calculations. I also modified the units to be in μF, which makes much more sense with the type of capacitors being used. 
Lab 4 had incorrect units and references to capacitors (sloppy copying)